### PR TITLE
Add per block fixes, pre-generate EVM TXs for batched execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ DFI emissions handler bot
   - `ethers` is also re-exported from `cli.ts` - so that you use the same
     version and mixed version conflicts.
   - Use the re-exported ethers for interacting with the EVM.
-- Note: Use the cli driver for use-cases wider than the intended ones
-  with heavy caution.
+- Note: Use the cli driver for use-cases wider than the intended ones with heavy
+  caution.
 - It uses double precision floating point for many ops, which will quickly
   result in loss of precision and start approximating.
 - It's OK-ish for the intended use case of the bot for now. But this is a TODO.
@@ -38,9 +38,9 @@ DFI emissions handler bot
   much simpler framework for other things.
 - Some eth* calls are baked in for quick testing only. Prefer ethers js instead
   to avoid precision loss.
-- Note: Floats are used in areas where we pass to DFI / BTC CLI. This doesn't accept
-  beyond 8 decimal precision and will throw an error anyway if `toFixed(8)`
-  can't represent this. Why it's safe-ish.
+- Note: Floats are used in areas where we pass to DFI / BTC CLI. This doesn't
+  accept beyond 8 decimal precision and will throw an error anyway if
+  `toFixed(8)` can't represent this. Why it's safe-ish.
 - Currently the used methods for the bot serialize them with `toFixed(8)` as
   needed (Eg: `PoolSwapArgs` goes through `makeSerializable` that's use
   `toFixed(8)` to round it.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -424,10 +424,16 @@ export async function processRun(path: string, ...args: string[]) {
 }
 
 export async function processOutput(path: string, ...args: string[]) {
-  const cmd = new Deno.Command(path, { args, stdout: "piped", stderr: "piped" });
+  const cmd = new Deno.Command(path, {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  });
   const { code, success, stdout, stderr } = await cmd.output();
   if (!success) {
-    throw new Error(`process code: ${code}, ${new TextDecoder().decode(stderr)}`);
+    throw new Error(
+      `process code: ${code}, ${new TextDecoder().decode(stderr)}`,
+    );
   }
   return new Output(new TextDecoder().decode(stdout));
 }

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -466,6 +466,7 @@ export async function distributeDusdToContracts(
         if (txVal.nonce != null) {
           txVal.nonce += i++;
         }
+        tx.v = txVal;
       };
       if (currentHeight.value == (await cli.getBlockHeight()).value) {
         return descCopy;

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -481,9 +481,9 @@ export async function distributeDusdToContracts(
   ];
 
   // We send the approvals in first.
-  await sendTxsInParallel(cli, txDescriptors.slice(0, 1), signer);
+  await sendTxsInParallel(cli, txDescriptors.slice(0, 2), signer);
   // Then we send the TXs
-  await sendTxsInParallel(cli, txDescriptors.slice(2, 3), signer);
+  await sendTxsInParallel(cli, txDescriptors.slice(2, 4), signer);
 
   // for (const txDesc of txDescriptors) {
   //   console.log(

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -484,7 +484,7 @@ export async function distributeDusdToContracts(
   // Then we send the TXs
   // await sendTxsInParallel(cli, txDescriptors.slice(2, 4), signer);
 
-  // We send approvals and transfers in parallel, so we hard code the 
+  // We send approvals and transfers in parallel, so we hard code the
   // gas limit to reasonable value.
   await sendTxsInParallel(cli, txDescriptors, signer, 100_000n);
 
@@ -511,7 +511,7 @@ async function sendTxsInParallel(
   cli: DfiCli,
   txDesc: TxDescriptor[],
   signer: ethers.Signer,
-  gasLimit = 0n, 
+  gasLimit = 0n,
 ) {
   const txsForContractTransfer = await (async () => {
     while (true) {
@@ -528,7 +528,7 @@ async function sendTxsInParallel(
           txVal.nonce += i++;
         }
         if (gasLimit > 0n) {
-          txVal.gasLimit = gasLimit;          
+          txVal.gasLimit = gasLimit;
         }
         tx.v = txVal;
       }

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -117,7 +117,7 @@ export async function createContext(
   const dfiPriceForDusd = poolPairInfoDusdDfi["reserveB/reserveA"];
   const dfiForDusdCappedPerBlock = dfiPriceForDusd * maxDUSDPerBlock;
   const dfiToSwapPerBlock = Math.min(
-    balanceTokensInitDfi,
+    Math.floor(balanceTokensInitDfi / diffBlocks),
     dfiForDusdCappedPerBlock,
   );
   const dfiToSwapForDiffBlocks = dfiToSwapPerBlock * diffBlocks;
@@ -479,16 +479,16 @@ export async function distributeDusdToContracts(
     },
   ];
 
-  // await sendTxsInParallel(cli, txDescriptors, signer);
+  await sendTxsInParallel(cli, txDescriptors, signer);
 
-  for (const txDesc of txDescriptors) {
-    console.log(
-      `${txDesc.label}: ${[...txDesc.args]}`,
-    );
-    const tx = await txDesc.gen(...txDesc.args);
-    tx.nonce = await evm.getTransactionCount(emissionsAddrErc55.value);
-    (await signer.sendTransaction(tx)).wait();
-  }
+  // for (const txDesc of txDescriptors) {
+  //   console.log(
+  //     `${txDesc.label}: ${[...txDesc.args]}`,
+  //   );
+  //   const tx = await txDesc.gen(...txDesc.args);
+  //   tx.nonce = await evm.getTransactionCount(emissionsAddrErc55.value);
+  //   (await signer.sendTransaction(tx)).wait();
+  // }
 
   return true;
 }

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -523,6 +523,9 @@ async function sendTxsInParallel(
         if (txVal.nonce != null) {
           txVal.nonce += i++;
         }
+        //have to set gaslimit ourself, cause due to the "missing" approve onchain (its pending in the tx before), 
+        //the gasEstimate fails. We know the gas of approve and addRewards is below 100k, and tx is anyway only using what it needs.
+        txVal.gasLimit = ethers.BigNumber.from(100_000)
         tx.v = txVal;
       }
       if (currentHeight.value == (await cli.getBlockHeight()).value) {

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -471,7 +471,6 @@ export async function distributeDusdToContracts(
       args: [evmAddr1AmountInWei],
       v: null,
     },
-
     {
       label: "transfer DUSD to contract 2",
       gen: cxLocks2y.addRewards.populateTransaction,

--- a/src/impl.ts
+++ b/src/impl.ts
@@ -460,17 +460,18 @@ export async function distributeDusdToContracts(
       v: null as ethers.ContractTransaction | null,
     },
     {
-      label: "transfer DUSD to contract 1",
-      gen: cxLocks1y.addRewards.populateTransaction,
-      args: [evmAddr1AmountInWei],
-      v: null,
-    },
-    {
       label: "approve DUSD to contract 2",
       gen: cxDusd.approve.populateTransaction,
       args: [evmAddr2, evmAddr2AmountInWei],
       v: null,
     },
+    {
+      label: "transfer DUSD to contract 1",
+      gen: cxLocks1y.addRewards.populateTransaction,
+      args: [evmAddr1AmountInWei],
+      v: null,
+    },
+
     {
       label: "transfer DUSD to contract 2",
       gen: cxLocks2y.addRewards.populateTransaction,
@@ -479,7 +480,10 @@ export async function distributeDusdToContracts(
     },
   ];
 
-  await sendTxsInParallel(cli, txDescriptors, signer);
+  // We send the approvals in first.
+  await sendTxsInParallel(cli, txDescriptors.slice(0, 1), signer);
+  // Then we send the TXs
+  await sendTxsInParallel(cli, txDescriptors.slice(2, 3), signer);
 
   // for (const txDesc of txDescriptors) {
   //   console.log(


### PR DESCRIPTION
- This PR sets up the base for https://github.com/prasannavl/dfi-emissions-handler-bot/issues/3
- But currently results in an error, right away on gas estimation of the first send. Error below. 
- Leaving it here, in case someone is able to see this through to completion in the near-term.

```
Error: missing revert data (action="estimateGas", data=null, reason=null, transaction={ "data": "0xbeceed39000000000000000000000000000000000000000000000010f9dea48234dc0000", "from": "0x9D6d3E01Aa98A39E354D5940cE45A2371c7F04eb", "to": "0x78090025D0F3Cd3dC189Eb5DBeEC9FD901122be2" }, invocation=null, revert=null, code=CALL_EXCEPTION, version=6.10.0)
    at nt (https://esm.sh/v135/ethers@6.10.0/denonext/utils.js:2:1724)
    at Tr (https://esm.sh/v135/ethers@6.10.0/denonext/abi.js:2:39035)
    at Function.getBuiltinCallException (https://esm.sh/v135/ethers@6.10.0/denonext/abi.js:2:40353)
    at b.getRpcError (https://esm.sh/v135/ethers@6.10.0/denonext/providers.js:3:62758)
    at https://esm.sh/v135/ethers@6.10.0/denonext/providers.js:3:57880
    at eventLoopTick (ext:core/01_core.js:182:7) {
  code: "CALL_EXCEPTION",
  action: "estimateGas",
  data: null,
  reason: null,
  transaction: {
    to: "0x78090025D0F3Cd3dC189Eb5DBeEC9FD901122be2",
    data: "0xbeceed39000000000000000000000000000000000000000000000010f9dea48234dc0000",
    from: "0x9D6d3E01Aa98A39E354D5940cE45A2371c7F04eb"
  },
  invocation: null,
  revert: null,
  shortMessage: "missing revert data",
  info: {
    error: {
      code: -32001,
      message: "Custom error: transaction execution failed"
    },
    payload: {
      method: "eth_estimateGas",
      params: [
        {
          from: "0x9d6d3e01aa98a39e354d5940ce45a2371c7f04eb",
          to: "0x78090025d0f3cd3dc189eb5dbeec9fd901122be2",
          data: "0xbeceed39000000000000000000000000000000000000000000000010f9dea48234dc0000"
        }
      ],
      id: 13,
      jsonrpc: "2.0"
    }
  }
}

```